### PR TITLE
Fixed path error with docker-compose

### DIFF
--- a/src/Services/ShellCommandRunnerService.php
+++ b/src/Services/ShellCommandRunnerService.php
@@ -58,6 +58,7 @@ class ShellCommandRunnerService
             'SWDOCKER_VARNISH' => $this->input->getOption('use-varnish') || !empty(getenv('SWDOCKER_VARNISH')) ? '-varnish' : '',
             'SWDOCKER_IONCUBE' => $this->input->getOption('use-ioncube') || !empty(getenv('SWDOCKER_IONCUBE')) ? '-ioncube' : '',
             'SWDOCKER_XDEBUG' => $this->input->getOption('use-xdebug') || !empty(getenv('SWDOCKER_XDEBUG')) ? '-xdebug' : '',
+            'PATH' => getenv('PATH')
         ]);
         $process->run(function ($type, $buffer) use ($input, $output) {
             $io = new SymfonyStyle($input, $output);


### PR DESCRIPTION
Fixes docker-compose error with
```
Traceback (most recent call last):
  File "bin/docker-compose", line 6, in <module>
  File "compose/cli/main.py", line 71, in main
  File "compose/cli/main.py", line 127, in perform_command
  File "compose/cli/main.py", line 845, in run
  File "compose/cli/main.py", line 1321, in run_one_off_container
  File "compose/cli/main.py", line 1402, in call_docker
  File "distutils/spawn.py", line 176, in find_executable
  File "os.py", line 669, in __getitem__
KeyError: 'PATH'
[19068] Failed to execute script docker-compose
```